### PR TITLE
fix path so kustomize adds prefixes to the webhook service

### DIFF
--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -5,12 +5,12 @@ nameReference:
   fieldSpecs:
   - kind: CustomResourceDefinition
     group: apiextensions.k8s.io
-    path: spec/conversion/webhookClientConfig/service/name
+    path: spec/conversion/webhook/clientConfig/service/name
 
 namespace:
 - kind: CustomResourceDefinition
   group: apiextensions.k8s.io
-  path: spec/conversion/webhookClientConfig/service/namespace
+  path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
 
 varReference:


### PR DESCRIPTION
The path seems to have changes with the upgrade of the CRD to version v1.

refs #1531

**What this PR does / why we need it**:

**Special notes for your reviewer**:
Not sure if it fixes all related issues, but worked when generating the CRD yamls locally.
 